### PR TITLE
remove automatic polyfilling

### DIFF
--- a/demo/index.jsx
+++ b/demo/index.jsx
@@ -1,6 +1,6 @@
 /* eslint new-cap:0 no-unused-vars:0 */
 'use strict';
-
+require('babel-core/polyfill')
 var React = require('react/addons');
 var Playground = require('playground');
 var Button = require('./components/button');
@@ -16,7 +16,7 @@ var Index = React.createClass({
   render() {
     return (
       <div className="component-documentation">
-        <Playground codeText={componentExample} scope={{React: React, Button: Button}}/>
+        <Playground codeText={componentExample} scope={{React: React, Button: Button}} babelConfig={{ stage: 0 }}/>
         <Playground codeText={componentExample} scope={{React: React, Button: Button}} collapsableCode={true}/>
         <Playground
           codeText={componentExample}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "react": "0.13.x"
   },
   "devDependencies": {
-    "babel-core": "^4.7.16",
     "babel-eslint": "^2.0.2",
     "babel-loader": "^5.0.0",
     "chai": "^2.2.0",

--- a/src/playground.jsx
+++ b/src/playground.jsx
@@ -1,6 +1,5 @@
 /* eslint new-cap:0 no-unused-vars:0 */
 'use strict';
-import polyfill from "babel/polyfill";
 import React from 'react/addons';
 
 import Editor from "./editor";


### PR DESCRIPTION
Polyfills should generally only be required by applications, not modules. If
another module/app requires the polyfill babel will throw and break,
leaving the module unusable. Generally we would just use the runtime
transformer but that doesn't work for on the fly compilation. Still it
is better to add a note letting the user know they need to include any
polyfills for their code (a la React) then presume to pollute their
global scope. ALSO the polyfill is enormous, and probably overkill for
most people.