### PR TITLE
Added prop for passing config object to babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,14 @@ Turns preview into a simple console for testing out ES6 code. Use `console.log()
   es6Console={true}
   codeText={es6Example} />
 ```
+
+###babelConfig
+_React.PropTypes.object_
+
+An object of [configuration options](http://babeljs.io/docs/usage/options/) that the playground should pass to babel. Use to adjust, or limit the features you want the playground to support.
+
+```
+<Playground
+  babelConfig={{ stage: 0, loose: ['all']}}
+  codeText={es6Example} />
+```

--- a/src/es6-preview.jsx
+++ b/src/es6-preview.jsx
@@ -7,7 +7,14 @@ import babel from 'babel-core/browser';
 const Preview = React.createClass({
     propTypes: {
       code: React.PropTypes.string.isRequired,
-      scope: React.PropTypes.object.isRequired
+      scope: React.PropTypes.object.isRequired,
+      babelConfig: React.PropTypes.object
+    },
+
+    getDefaultProps() {
+      return {
+        babelConfig: {stage: 1}
+      }
     },
 
     componentDidMount() {
@@ -30,7 +37,7 @@ const Preview = React.createClass({
           ' \n return list;' +
         '\n});',
 
-      { stage: 1 }
+      this.props.babelConfig
       ).code;
     },
 
@@ -89,7 +96,7 @@ const Preview = React.createClass({
 
     render() {
         return <div ref="mount" />;
-    },
+    }
 });
 
 export default Preview;

--- a/src/playground.jsx
+++ b/src/playground.jsx
@@ -17,7 +17,8 @@ const ReactPlayground = React.createClass({
     propDescriptionMap: React.PropTypes.string,
     theme: React.PropTypes.string,
     noRender: React.PropTypes.bool,
-    es6Console: React.PropTypes.bool
+    es6Console: React.PropTypes.bool,
+    babelConfig: React.PropTypes.object
   },
 
   getDefaultProps() {
@@ -77,6 +78,7 @@ const ReactPlayground = React.createClass({
           <Preview
             code={this.state.code}
             scope={this.props.scope}
+            babelConfig={this.props.babelConfig}
             noRender={this.props.noRender} />
           }
         </div>

--- a/src/preview.jsx
+++ b/src/preview.jsx
@@ -7,12 +7,19 @@ import babel from 'babel-core/browser';
 const Preview = React.createClass({
     propTypes: {
       code: React.PropTypes.string.isRequired,
-      scope: React.PropTypes.object.isRequired
+      scope: React.PropTypes.object.isRequired,
+      babelConfig: React.PropTypes.object
     },
 
     getInitialState() {
       return {
         error: null
+      }
+    },
+
+    getDefaultProps() {
+      return {
+        babelConfig: {stage: 1}
       }
     },
 
@@ -39,14 +46,14 @@ const Preview = React.createClass({
                 '}' +
               '});' +
             '\n});',
-        { stage: 1 }
+        this.props.babelConfig
         ).code;
       } else {
         return babel.transform(
             '(function(' + Object.keys(this.props.scope).join(',') + ', mountNode) {' +
               this.props.code +
             '\n});',
-        { stage: 1 }
+        this.props.babelConfig
         ).code;
       }
     },


### PR DESCRIPTION
Allows configuring specific features that should or should not be
transpiled, and lets you enable stage: 0 features like class property
initializers