### PR TITLE
Bug: fix object console output

### DIFF
--- a/src/es6-preview.jsx
+++ b/src/es6-preview.jsx
@@ -53,9 +53,7 @@ const wrapMap = {
             {(first ? "" : ", ")  + key}
           </span>
           {': '}
-          <span style={{color: "#F2777A"}}>
-            {'"' + obj[key] + '"'}
-            </span>
+          {wrapMap["wrap" + getType(obj[key])](obj[key])}
         </span>
       );
 


### PR DESCRIPTION
This updates the console output of objects so that all types are highlighted properly, not printed as strings.

/cc @kenwheeler 