### PR TITLE
Add Postinstall and format package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,27 +1,27 @@
 {
   "name": "component-playground",
-  "version": "0.0.13",
   "description": "A component for rendering React components with editable source and live preview",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/FormidableLabs/component-playground.git"
-  },
   "keywords": [
     "React",
     "playground",
     "live",
     "component"
   ],
+
+  "version": "0.0.13",
   "author": "Ken Wheeler",
-  "license": "MIT",
+
+  "homepage": "https://github.com/FormidableLabs/component-playground#readme",
   "bugs": {
     "url": "https://github.com/FormidableLabs/component-playground/issues"
   },
-  "homepage": "https://github.com/FormidableLabs/component-playground#readme",
+
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FormidableLabs/component-playground.git"
+  },
+  "private": false,
+
   "dependencies": {
     "babel": "^5.1.11",
     "babel-core": "^5.1.13"
@@ -62,5 +62,15 @@
     "style-loader": "~0.10.2",
     "webpack": "^1.7.3",
     "webpack-dev-server": "^1.7.0"
-  }
+  },
+
+  "main": "index.js",
+  "engines":{
+    "node": ">= 0.10.0"
+  },
+  "scripts": {
+    "postinstall": "gulp build"
+  },
+
+  "license": "MIT",
 }


### PR DESCRIPTION
This PR does 2 things:

1. Add postinstall to the scripts section so that component-playground is immediately useful
2. make the package.json look real nice. 