### PR TITLE
Turn on linting with the standard ruleset

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,85 +1,186 @@
-{
-    "env": {
-        "node": true,
-        "browser": true,
-        "mocha": true
-    },
-    "globals": {
-        "navigator",
-        "$serverSide",
-        "$isiOS",
-        "$isAndroid",
-        "$isBrowser"
-    },
-    "parser": "babel-eslint",
-    "ecmaFeatures": {
-        "arrowFunctions": true,
-        "binaryLiterals": true,
-        "blockBindings": true,
-        "classes": true,
-        "defaultParams": true,
-        "destructuring": true,
-        "forOf": true,
-        "generators": true,
-        "modules": true,
-        "objectLiteralComputedProperties": true,
-        "objectLiteralDuplicateProperties": true,
-        "objectLiteralShorthandMethods": true,
-        "objectLiteralShorthandProperties": true,
-        "spread": true,
-        "superInFunctions": true,
-        "templateStrings": true,
-        "unicodeCodePointEscapes": true,
-        "jsx": true
-    },
-    "rules": {
+---
+globals:
+  # We're just going to assume a CommonJS / Webpack world...
+  require: false
+  module: false
+  process: false
 
-        // Lint Rules
+ecmaFeatures:
+  jsx: true
+  modules: true
 
-        "no-bitwise": 2,
-        "eqeqeq": 2,
-        "guard-for-in": 2,
-        "no-use-before-define": 2,
-        "no-caller": 2,
-        "no-new": 0,
-        "no-undef": 0, // Fix Me
-        "no-unused-vars": 0, // Fix Me
-        "strict": 0,
-        "max-params": [2, 5],
-        "semi": 0,
-        "no-cond-assign": 0,
-        "no-loop-func": 0,
-        "no-shadow": 0,
-        "no-underscore-dangle": 0,
+env:
+  es6: true
+  node: true
+  browser: true
 
-        // Style Rules
+globals:
+  fetch: false                      # Expect a `fetch` polyfill.
+  CodeMirror: false
 
-        "no-with": 1,
-        "no-eval": 1,
-        "space-after-keywords": 1,
+rules:
+  no-extra-parens: 0  # Ugh. Want `return (<Foo />);` to be allowed.
+  no-var: 2
+  no-alert: 2
+  no-array-constructor: 2
+  no-bitwise: 2
+  no-caller: 2
+  no-catch-shadow: 2
+  no-comma-dangle: 2
+  no-cond-assign: 2
+  no-console: 2
+  no-constant-condition: 2
+  no-continue: 0
+  no-control-regex: 2
+  no-debugger: 2
+  no-delete-var: 2
+  no-div-regex: 0
+  no-dupe-keys: 2
+  no-dupe-args: 2
+  no-duplicate-case: 2
+  no-else-return: 0
+  no-empty: 2
+  no-empty-class: 2
+  no-empty-label: 2
+  no-eq-null: 0
+  no-eval: 2
+  no-ex-assign: 2
+  no-extend-native: 2
+  no-extra-bind: 2
+  no-extra-boolean-cast: 2
+  no-extra-semi: 2
+  no-extra-strict: 2
+  no-fallthrough: 2
+  no-floating-decimal: 0
+  no-func-assign: 2
+  no-implied-eval: 2
+  no-inline-comments: 0
+  no-inner-declarations: [2, "functions"]
+  no-invalid-regexp: 2
+  no-irregular-whitespace: 2
+  no-iterator: 2
+  no-label-var: 2
+  no-labels: 2
+  no-lone-blocks: 2
+  no-lonely-if: 2
+  no-loop-func: 2
+  no-mixed-requires: 2
+  no-mixed-spaces-and-tabs: 2
+  no-multi-spaces: 2
+  no-multi-str: 2
+  no-multiple-empty-lines: [2, { max: 2 }]
+  no-native-reassign: 2
+  no-negated-in-lhs: 2
+  no-nested-ternary: 2
+  no-new: 2
+  no-new-func: 2
+  no-new-object: 2
+  no-new-require: 2
+  no-new-wrappers: 2
+  no-obj-calls: 2
+  no-octal: 2
+  no-octal-escape: 2
+  no-param-reassign: 0
+  no-path-concat: 0
+  no-plusplus: 0
+  no-process-env: 0
+  no-process-exit: 2
+  no-proto: 2
+  no-redeclare: 2
+  no-regex-spaces: 2
+  no-reserved-keys: 0
+  no-restricted-modules: 0
+  no-return-assign: 2
+  no-script-url: 2
+  no-self-compare: 2
+  no-sequences: 2
+  no-shadow: 2
+  no-shadow-restricted-names: 2
+  no-space-before-semi: 0
+  no-spaced-func: 2
+  no-sparse-arrays: 2
+  no-sync: 0
+  no-ternary: 0
+  no-trailing-spaces: 2
+  no-throw-literal: 0
+  no-undef: 2
+  no-undef-init: 2
+  no-undefined: 0
+  no-underscore-dangle: 0
+  no-unreachable: 2
+  no-unused-expressions: 2
+  no-unused-vars: [2, {
+    vars: "all",
+    args: "after-used" }]
+  no-use-before-define: 2
+  no-void: 0
+  no-var: 0
+  no-warning-comments: 0
+  no-with: 2
+  no-wrap-func: 2
+  block-scoped-var: 0
+  brace-style: [2, "1tbs", { "allowSingleLine": true }]
+  camelcase: 2
+  comma-dangle: [2, "never"]
+  comma-spacing: 2
+  comma-style: [2, "last"]
+  complexity: [2, 11]
+  consistent-return: 2
+  consistent-this: [2, "self"]
+  curly: [2, "all"]
+  default-case: 0
+  dot-notation: [2, { allowKeywords: true }]
+  eol-last: 2
+  eqeqeq: 2
+  func-names: 0
+  func-style: [2, "expression"]
+  generator-star: 0
+  generator-star-spacing: 0
+  global-strict: [2, "always"]
+  guard-for-in: 0
+  handle-callback-err: 0
+  indent: [2, 2]
+  key-spacing: [2, {
+    beforeColon: false,
+    afterColon: true }]
+  max-depth: [2, 4]
+  max-len: [2, 100, 2]
+  max-nested-callbacks: [2, 3]
+  max-params: [2, 3]
+  max-statements: [2, 15]
+  new-cap: 2
+  new-parens: 2
+  newline-after-var: 0
+  object-shorthand: 0
+  one-var: [2, "never"]
+  operator-assignment: [2, "always"]
+  operator-linebreak: 0
+  padded-blocks: 0
+  quote-props: 0
+  quotes: [2, "double"]
+  radix: 0
+  semi: 2
+  semi-spacing: [2, { before : false, after: true}]
+  sort-vars: 0
+  space-after-keywords: [2, "always"]
+  space-before-blocks: [2, "always"]
+  space-before-function-paren: [2, {
+    anonymous: "always",
+    named: "never" }]
+  space-in-brackets: [0, "always"]
+  space-in-parens: [2, "never"]
+  space-infix-ops: 2
+  space-return-throw-case: 2
+  space-unary-ops: [2, {
+    words: true,
+    nonwords: false }]
+  spaced-line-comment: [2, "always"]
 
-        "curly": [1, "all"],
-        "space-before-blocks": 1,
-        "no-empty": 1,
-
-        "space-before-function-parentheses": [1, "never"],
-        "wrap-iife": 1,
-
-        "space-in-brackets": [1, "never"],
-        "space-in-parens": [1, "never"],
-
-        "space-infix-ops": 1,
-        "dot-notation": 1,
-
-        "camelcase": 1,
-        "no-multi-str": 1,
-
-        "no-mixed-spaces-and-tabs": 1,
-        "no-trailing-spaces": 1,
-        "eol-last" : 1,
-
-        "comma-spacing": [1, {"before": false, "after": true}],
-        "indent": [1, 2],
-        "quotes": [1, "single"]
-    }
-}
+  strict: 0
+  use-isnan: 2
+  valid-jsdoc: 2
+  valid-typeof: 2
+  vars-on-top: 0
+  wrap-iife: 0
+  wrap-regex: 0
+  yoda: [2, "never"]

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,58 +1,63 @@
-'use strict';
+"use strict";
 
-var gulp = require('gulp');
-var gutil = require('gulp-util');
-var babel = require('gulp-babel');
-var del = require('del');
-var webpack = require('webpack');
-var gwebpack = require('gulp-webpack');
+var gulp = require("gulp");
+var gutil = require("gulp-util");
+var babel = require("gulp-babel");
+var del = require("del");
 var WebpackDevServer = require("webpack-dev-server");
 
-var eslint= require('gulp-eslint');
-var karma = require('karma').server;
+var eslint = require("gulp-eslint");
+var karma = require("karma").server;
 
-var webpackDemoConfig = require('./demo/webpack.demo.config.js');
+var webpackDemoConfig = require("./demo/webpack.demo.config.js");
 
-gulp.task('clean', function(cb){
-  del(['lib'], cb)
+gulp.task("clean", function (cb) {
+  del(["lib"], cb);
 });
 
-gulp.task("babel", ['clean'], function() {
-  return gulp.src('src/*.js*')
-        .pipe(babel())
-        .pipe(gulp.dest('lib'));
+gulp.task("babel", ["clean"], function () {
+  return gulp.src("src/*.js*")
+    .pipe(babel())
+    .pipe(gulp.dest("lib"));
 });
 
-gulp.task('demo', ['build'], function(callback) {
+gulp.task("demo", ["build"], function () {
   var compiler = webpackDemoConfig;
 
   new WebpackDevServer(compiler, {
-      contentBase: './demo',
+      contentBase: "./demo",
       hot: true,
-      publicPath: '/demo/assets/',
+      publicPath: "/demo/assets/",
       stats: {
         colors: true
       }
-  }).listen(8081, "localhost", function(err) {
-    if(err) throw new gutil.PluginError("webpack-dev-server", err);
+  }).listen(8081, "localhost", function (err) {
+    if (err) {
+      throw new gutil.PluginError("webpack-dev-server", err);
+    }
     gutil.log("[demo]", "http://localhost:8081/");
   });
 });
 
-gulp.task('lint', function () {
-  return gulp.src(['src/**/*.js'])
+gulp.task("lint", function () {
+  return gulp.src([
+      "src/**/*.jsx",
+      "demo/**/*.jsx",
+      "./Gulpfile.js",
+      "./index.js"
+    ])
     .pipe(eslint())
-    .pipe(eslint.format())
+    .pipe(eslint.format());
 });
 
 
-gulp.task("karma", ['lint'], function() {
+gulp.task("karma", ["lint"], function () {
   karma.start({
-    configFile: __dirname + '/karma.conf.js',
+    configFile: __dirname + "/karma.conf.js",
     singleRun: true
   });
 });
 
-gulp.task('test', ['karma']);
-gulp.task('build', ['lint', 'clean', 'babel']);
-gulp.task('default', ['demo']);
+gulp.task("test", ["karma"]);
+gulp.task("build", ["lint", "clean", "babel"]);
+gulp.task("default", ["demo"]);

--- a/demo/components/button.jsx
+++ b/demo/components/button.jsx
@@ -1,7 +1,7 @@
 /* eslint new-cap:0 no-unused-vars:0 */
-'use strict';
+"use strict";
 
-import React from 'react/addons';
+import React from "react/addons";
 
 const Button = React.createClass({
   propTypes: {
@@ -12,7 +12,7 @@ const Button = React.createClass({
   getDefaultProps() {
     return {
       darkMode: false
-    }
+    };
   },
 
   render() {
@@ -21,7 +21,7 @@ const Button = React.createClass({
         {this.props.children}
       </button>
     );
-  },
+  }
 });
 
 export default Button;

--- a/demo/components/debug-info.jsx
+++ b/demo/components/debug-info.jsx
@@ -1,7 +1,7 @@
 /* eslint new-cap:0 no-unused-vars:0 */
-'use strict';
+"use strict";
 
-import React from 'react/addons';
+import React from "react/addons";
 
 const Button = React.createClass({
   contextTypes: {
@@ -10,7 +10,7 @@ const Button = React.createClass({
 
   render() {
     return (
-      <h1>ENV: {this.context.environment || 'development'}</h1>
+      <h1>ENV: {this.context.environment || "development"}</h1>
     );
   }
 });

--- a/demo/index.jsx
+++ b/demo/index.jsx
@@ -1,17 +1,17 @@
 /* eslint new-cap:0 no-unused-vars:0 */
-'use strict';
+"use strict";
 
-var React = require('react/addons');
-var Playground = require('playground');
+var React = require("react/addons");
+var Playground = require("playground");
 
-require('./styles/syntax.css');
-require('./styles/codemirror.css');
-require('./styles/demo.css');
+require("./styles/syntax.css");
+require("./styles/codemirror.css");
+require("./styles/demo.css");
 
-var Button = require('./components/button');
+var Button = require("./components/button");
 var componentExample = require("raw!./examples/component.example");
 
-var DebugInfo = require('./components/debug-info');
+var DebugInfo = require("./components/debug-info");
 var contextExample = require("raw!./examples/context.example");
 
 var es6Example = require("raw!./examples/es6.example");
@@ -48,4 +48,4 @@ var Index = React.createClass({
   }
 });
 
-React.render(<Index/>, document.getElementById('root'));
+React.render(<Index/>, document.getElementById("root"));

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
-var Playground = require('./lib/playground');
+"use strict";
+
+var Playground = require("./lib/playground");
 
 module.exports = Playground;

--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
     "react": "0.13.x"
   },
   "devDependencies": {
-    "babel-eslint": "^2.0.2",
+    "babel-eslint": "^3.1.20",
     "babel-loader": "^5.3.0",
     "chai": "^3.0.0",
     "css-loader": "~0.15.1",
     "del": "^1.1.1",
     "gulp": "^3.8.11",
     "gulp-babel": "^5.1.0",
-    "gulp-eslint": "^0.7.0",
+    "gulp-eslint": "^0.15.0",
     "gulp-open": "^0.3.2",
     "gulp-util": "^3.0.4",
     "gulp-webpack": "^1.3.0",

--- a/src/doc.jsx
+++ b/src/doc.jsx
@@ -1,44 +1,44 @@
-'use strict';
+"use strict";
 
-import React from 'react/addons';
+import React from "react/addons";
 
 var propTypesArray = [{
-  key: 'array',
+  key: "array",
   test: React.PropTypes.array,
   isRequired: React.PropTypes.array.isRequired
 }, {
-  key: 'boolean',
+  key: "boolean",
   test: React.PropTypes.bool,
   isRequired: React.PropTypes.bool.isRequired
 }, {
-  key: 'function',
+  key: "function",
   test: React.PropTypes.func,
   isRequired: React.PropTypes.func.isRequired
 }, {
-  key: 'number',
+  key: "number",
   test: React.PropTypes.number,
   isRequired: React.PropTypes.number.isRequired
 }, {
-  key: 'object',
+  key: "object",
   test: React.PropTypes.object,
   isRequired: React.PropTypes.array.isRequired
 }, {
-  key: 'string',
+  key: "string",
   test: React.PropTypes.string,
   isRequired: React.PropTypes.string.isRequired
 }, {
-  key: 'node',
+  key: "node",
   test: React.PropTypes.node,
   isRequired: React.PropTypes.node.isRequired
 }, {
-  key: 'element',
+  key: "element",
   test: React.PropTypes.element,
   isRequired: React.PropTypes.element.isRequired
 }];
 
 var getReactPropType = function (propTypeFunc) {
   var propType = {
-    name: 'custom',
+    name: "custom",
     isRequire: false
   };
 
@@ -58,7 +58,7 @@ var getReactPropType = function (propTypeFunc) {
   }
 
   return propType;
-}
+};
 
 module.exports = React.createClass({
   propTypes: {
@@ -80,7 +80,7 @@ module.exports = React.createClass({
         propTypes.push({
           propName: propName,
           type: getReactPropType(this.props.componentClass.propTypes[propName]),
-          description: this.props.propDescriptionMap[propName] || ''
+          description: this.props.propDescriptionMap[propName] || ""
         });
       }
     }
@@ -92,9 +92,9 @@ module.exports = React.createClass({
             return (
               <li key={propObj.propName}>
                 <b>{propObj.propName}</b>
-                <i>{': ' + propObj.type.name}</i>
-                {propObj.description && ' - ' + propObj.description}
-                <b>{propObj.type.isRequired ? ' required' : ''}</b>
+                <i>{": " + propObj.type.name}</i>
+                {propObj.description && " - " + propObj.description}
+                <b>{propObj.type.isRequired ? " required" : ""}</b>
               </li>
             );
           })}

--- a/src/editor.jsx
+++ b/src/editor.jsx
@@ -1,12 +1,12 @@
 /* eslint new-cap:0 no-unused-vars:0 */
-'use strict';
+"use strict";
 
-import React from 'react/addons';
+import React from "react/addons";
 
 const Editor = React.createClass({
   componentDidMount() {
     this.editor = CodeMirror.fromTextArea(this.refs.editor.getDOMNode(), {
-      mode: 'javascript',
+      mode: "javascript",
       lineNumbers: false,
       lineWrapping: true,
       smartIndent: false,
@@ -14,7 +14,7 @@ const Editor = React.createClass({
       theme: this.props.theme,
       readOnly: this.props.readOnly
     });
-    this.editor.on('change', this._handleChange);
+    this.editor.on("change", this._handleChange);
   },
 
   componentDidUpdate() {

--- a/src/es6-preview.jsx
+++ b/src/es6-preview.jsx
@@ -1,8 +1,8 @@
 /* eslint new-cap:0 no-unused-vars:0 */
-'use strict';
+"use strict";
 
-import React from 'react/addons';
-import babel from 'babel-core/browser';
+import React from "react/addons";
+import babel from "babel-core/browser";
 
 const getType = function (el) {
   let t = typeof el;
@@ -10,23 +10,23 @@ const getType = function (el) {
   if (Array.isArray(el)) {
     t = "array";
   } else if (el === null) {
-    t = "null"
+    t = "null";
   }
 
   return t;
-}
+};
 
 const wrapMap = {
   wrapnumber(num) {
-    return <span style={{color: "#6170d5"}}>{num}</span>
+    return (<span style={{color: "#6170d5"}}>{num}</span>);
   },
 
   wrapstring(str) {
-    return <span style={{color: "#F2777A"}}>{'"' + str + '"'}</span>
+    return (<span style={{color: "#F2777A"}}>{"'" + str + "'"}</span>);
   },
 
   wrapboolean(bool) {
-    return <span style={{color: "#48A1CF"}}>{bool ? "true" : "false"}</span>
+    return (<span style={{color: "#48A1CF"}}>{bool ? "true" : "false"}</span>);
   },
 
   wraparray(arr) {
@@ -54,9 +54,9 @@ const wrapMap = {
       pairs.push(
         <span>
           <span style={{color: "#8A6BA1"}}>
-            {(first ? "" : ", ")  + key}
+            {(first ? "" : ", ") + key}
           </span>
-          {': '}
+          {": "}
           {wrapMap["wrap" + getType(obj[key])](obj[key])}
         </span>
       );
@@ -64,118 +64,120 @@ const wrapMap = {
       first = false;
     }
 
-    return <i>{"Object {"}{pairs}{"}"}</i>
+    return (<i>{"Object {"}{pairs}{"}"}</i>);
   },
 
   wrapfunction() {
-    return <i style={{color: "#48A1CF"}}>{"function"}</i>
+    return (<i style={{color: "#48A1CF"}}>{"function"}</i>);
   },
 
   wrapnull() {
-    return <span style={{color: "#777"}}>{"null"}</span>
+    return (<span style={{color: "#777"}}>{"null"}</span>);
   },
 
   wrapundefined() {
-    return <span style={{color: "#777"}}>{"undefined"}</span>
+    return (<span style={{color: "#777"}}>{"undefined"}</span>);
   }
 };
 
 const Preview = React.createClass({
-    propTypes: {
-      code: React.PropTypes.string.isRequired,
-      scope: React.PropTypes.object.isRequired
-    },
+  propTypes: {
+    code: React.PropTypes.string.isRequired,
+    scope: React.PropTypes.object.isRequired
+  },
 
-    componentDidMount() {
+  componentDidMount() {
+    this._executeCode();
+  },
+
+  componentDidUpdate(prevProps) {
+    clearTimeout(this.timeoutID);
+    if (this.props.code !== prevProps.code) {
       this._executeCode();
-    },
+    }
+  },
 
-    componentDidUpdate(prevProps) {
-      clearTimeout(this.timeoutID);
-      if (this.props.code !== prevProps.code) {
-        this._executeCode();
-      }
-    },
+  _compileCode() {
+    return babel.transform(`
+      (function(${Object.keys(this.props.scope).join(",")}) {
+        var list = [];
+        var console = { log(...x) {
+          list.push({val: x, multipleArgs: x.length !== 1})
+        }};
+        ${this.props.code}
+        return list;
+      });
+    `, { stage: 1 }).code;
+  },
 
-    _compileCode() {
-      return babel.transform(`
-        (function(${Object.keys(this.props.scope).join(',')}) {
-          var list = [];
-          var console = { log(...x) {
-            list.push({val: x, multipleArgs: x.length !== 1})
-          }};
-          ${this.props.code}
-          return list;
-        });
-      `, { stage: 1 }).code;
-    },
+  _setTimeout() {
+    clearTimeout(this.timeoutID);
+    this.timeoutID = setTimeout.apply(null, arguments);
+  },
 
-    _setTimeout() {
-      clearTimeout(this.timeoutID);
-      this.timeoutID = setTimeout.apply(null, arguments);
-    },
+  _executeCode() {
+    var mountNode = this.refs.mount.getDOMNode();
 
-    _executeCode() {
-      var mountNode = this.refs.mount.getDOMNode();
+    try {
+      React.unmountComponentAtNode(mountNode);
+    } catch (e) {
+      console.error(e);
+    }
 
-      try {
-        React.unmountComponentAtNode(mountNode);
-      } catch (e) { }
-
-      try {
-        var scope = [];
-        for(var s in this.props.scope) {
-          if(this.props.scope.hasOwnProperty(s)){
-            scope.push(this.props.scope[s]);
-          }
+    try {
+      var scope = [];
+      for (var s in this.props.scope) {
+        if (this.props.scope.hasOwnProperty(s)) {
+          scope.push(this.props.scope[s]);
         }
-        scope.push(mountNode)
-        var compiledCode = this._compileCode();
-        var Component = React.createElement(
-          React.createClass({
-            _createConsoleLine(x, multipleArgs) {
-              return (
-                <span style={{marginRight: "20px"}}>
-                  {multipleArgs ?
-                    x.map((y) => { return this._createConsoleLine([y], false); }) :
-                    wrapMap["wrap" + getType(x[0])](x[0])}
-                </span>
-              );
-            },
-
-            render() {
-              return (
-                <div style={{padding: 15, fontFamily: "Consolas, Courier, monospace"}}>
-                  {eval(compiledCode).apply(null, scope).map(x => {
-                    return (
-                      <div
-                        style={{
-                          borderBottom: "1px solid #ccc",
-                          padding: "4px 0"
-                        }}>
-                        {this._createConsoleLine(x.val, x.multipleArgs)}
-                      </div>
-                    );
-                  })}
-                </div>
-              );
-            }
-          })
-        );
-        React.render(Component, mountNode);
-      } catch (err) {
-        this._setTimeout(function() {
-          React.render(
-            <div className="playgroundError">{err.toString()}</div>,
-            mountNode
-          );
-        }, 500);
       }
-    },
+      scope.push(mountNode);
+      var compiledCode = this._compileCode();
+      var Component = React.createElement(
+        React.createClass({
+          _createConsoleLine(x, multipleArgs) {
+            return (
+              <span style={{marginRight: "20px"}}>
+                {multipleArgs ?
+                  x.map((y) => { return this._createConsoleLine([y], false); }) :
+                  wrapMap["wrap" + getType(x[0])](x[0])}
+              </span>
+            );
+          },
 
-    render() {
-        return <div ref="mount" />;
-    },
+          render() {
+            return (
+              <div style={{padding: 15, fontFamily: "Consolas, Courier, monospace"}}>
+                {eval(compiledCode).apply(null, scope).map(x => {
+                  return (
+                    <div
+                      style={{
+                        borderBottom: "1px solid #ccc",
+                        padding: "4px 0"
+                      }}>
+                      {this._createConsoleLine(x.val, x.multipleArgs)}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          }
+        })
+      );
+      React.render(Component, mountNode);
+    } catch (err) {
+      this._setTimeout(function () {
+        React.render(
+          <div className="playgroundError">{err.toString()}</div>,
+          mountNode
+        );
+      }, 500);
+    }
+  },
+
+  render() {
+    return <div ref="mount" />;
+  }
 });
 
 export default Preview;

--- a/src/playground.jsx
+++ b/src/playground.jsx
@@ -1,7 +1,8 @@
-/* eslint new-cap:0 no-unused-vars:0 */
-'use strict';
+/* no-unused-vars:0 */
+"use strict";
+
 import polyfill from "babel/polyfill";
-import React from 'react/addons';
+import React from "react/addons";
 
 import Editor from "./editor";
 import Preview from "./preview";
@@ -23,10 +24,10 @@ const ReactPlayground = React.createClass({
 
   getDefaultProps() {
     return {
-      theme: 'monokai',
+      theme: "monokai",
       noRender: true,
       context: {}
-    }
+    };
   },
 
   getInitialState() {
@@ -62,7 +63,7 @@ const ReactPlayground = React.createClass({
             propDescriptionMap={this.props.propDescriptionMap} />
           : ""
         }
-        <div className={"playgroundCode"  + (this.state.expandedCode ? " expandedCode" : "")}>
+        <div className={"playgroundCode" + (this.state.expandedCode ? " expandedCode" : "")}>
           <Editor
             onChange={this._handleCodeChange}
             className="playgroundStage"
@@ -92,7 +93,7 @@ const ReactPlayground = React.createClass({
         </div>
       </div>
     );
-  },
+  }
 });
 
 export default ReactPlayground;

--- a/src/preview.jsx
+++ b/src/preview.jsx
@@ -1,8 +1,7 @@
-/* eslint new-cap:0 no-unused-vars:0 */
-'use strict';
+"use strict";
 
-import React from 'react/addons';
-import babel from 'babel-core/browser';
+import React from "react/addons";
+import babel from "babel-core/browser";
 
 const Preview = React.createClass({
     propTypes: {
@@ -13,7 +12,7 @@ const Preview = React.createClass({
     getInitialState() {
       return {
         error: null
-      }
+      };
     },
 
     componentDidMount() {
@@ -29,18 +28,18 @@ const Preview = React.createClass({
 
     _compileCode() {
       if (this.props.noRender) {
-        const generateContextTypes = function(context) {
+        const generateContextTypes = function (context) {
           const keys = Object.keys(context).map(val => `${val}: React.PropTypes.any.isRequired`);
           return `{ ${keys.join(", ")} }`;
         };
 
         return babel.transform(`
-          (function(${Object.keys(this.props.scope).join(', ')}, mountNode) {
+          (function (${Object.keys(this.props.scope).join(", ")}, mountNode) {
             return React.createClass({
               // childContextTypes: { test: React.PropTypes.string },
               childContextTypes: ${generateContextTypes(this.props.context)},
               getChildContext: function () { return ${JSON.stringify(this.props.context)}; },
-              render: function() {
+              render: function () {
                 return (
                   ${this.props.code}
                 );
@@ -50,7 +49,7 @@ const Preview = React.createClass({
         `, { stage: 1 }).code;
       } else {
         return babel.transform(`
-          (function(${Object.keys(this.props.scope).join(',')}, mountNode) {
+          (function (${Object.keys(this.props.scope).join(",")}, mountNode) {
             ${this.props.code}
           });
         `, { stage: 1 }).code;
@@ -69,13 +68,13 @@ const Preview = React.createClass({
 
         var scope = [];
 
-        for(var s in this.props.scope) {
-          if(this.props.scope.hasOwnProperty(s)){
+        for (var s in this.props.scope) {
+          if (this.props.scope.hasOwnProperty(s)) {
             scope.push(this.props.scope[s]);
           }
         }
 
-        scope.push(mountNode)
+        scope.push(mountNode);
 
         var compiledCode = this._compileCode();
         if (this.props.noRender) {
@@ -84,7 +83,7 @@ const Preview = React.createClass({
           );
           React.render(Component, mountNode);
         } else {
-          eval(compiledCode).apply(null, scope)
+          eval(compiledCode).apply(null, scope);
         }
 
         this.setState({
@@ -92,7 +91,7 @@ const Preview = React.createClass({
         });
       } catch (err) {
         var self = this;
-        this._setTimeout(function() {
+        this._setTimeout(function () {
           self.setState({
             error: err.toString()
           });
@@ -101,13 +100,15 @@ const Preview = React.createClass({
     },
 
     render() {
-        return (
-          <div>
-            {this.state.error !== null ? <div className="playgroundError">{this.state.error}</div> : null}
-            <div ref="mount" className="previewArea"/>
-          </div>
-        );
-    },
+      return (
+        <div>
+          {this.state.error !== null ?
+            <div className="playgroundError">{this.state.error}</div> :
+            null}
+          <div ref="mount" className="previewArea"/>
+        </div>
+      );
+    }
 });
 
 export default Preview;


### PR DESCRIPTION
It turns out linting was only looking at *.js files which there are none of in this project. This PR does four things:

1. Update the gulpfile to lint the whole project
2. Update ESLint to pull in the latest rules
3. Update the eslintrc with the FL standard - Note: this will get swapped out for the nice concise one next week but the rules will remain largely unchanged.
4. Correct the bazillion linting errors accrued by having it off.