### PR TITLE
Update deps, s/react\/addons/react, optional preview renderer

### DIFF
--- a/demo/components/button.jsx
+++ b/demo/components/button.jsx
@@ -1,7 +1,7 @@
 /* eslint new-cap:0 no-unused-vars:0 */
 "use strict";
 
-import React from "react/addons";
+import React from "react";
 
 const Button = React.createClass({
   propTypes: {

--- a/demo/components/debug-info.jsx
+++ b/demo/components/debug-info.jsx
@@ -1,7 +1,7 @@
 /* eslint new-cap:0 no-unused-vars:0 */
 "use strict";
 
-import React from "react/addons";
+import React from "react";
 
 const Button = React.createClass({
   contextTypes: {

--- a/demo/index.jsx
+++ b/demo/index.jsx
@@ -1,7 +1,7 @@
 /* eslint new-cap:0 no-unused-vars:0 */
 "use strict";
 
-var React = require("react/addons");
+var React = require("react");
 var Playground = require("playground");
 
 require("./styles/syntax.css");

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "private": false,
 
   "dependencies": {
-    "babel": "^5.1.11",
-    "babel-core": "^5.1.13"
+    "babel": "^5.8.23",
+    "babel-core": "^5.8.24"
   },
   "peerDependencies": {
     "react": "0.13.x"
@@ -34,18 +34,18 @@
     "babel-loader": "^5.3.0",
     "chai": "^3.0.0",
     "css-loader": "~0.15.1",
-    "del": "^1.1.1",
+    "del": "^2.0.2",
     "gulp": "^3.8.11",
     "gulp-babel": "^5.1.0",
     "gulp-eslint": "^0.15.0",
-    "gulp-open": "^0.3.2",
+    "gulp-open": "^1.0.0",
     "gulp-util": "^3.0.4",
     "gulp-webpack": "^1.3.0",
     "istanbul": "^0.3.13",
     "istanbul-instrumenter-loader": "^0.1.2",
-    "karma": "~0.12.21",
+    "karma": "~0.13.9",
     "karma-chrome-launcher": "~0.2.0",
-    "karma-coverage": "^0.4.2",
+    "karma-coverage": "^0.5.2",
     "karma-firefox-launcher": "~0.1.3",
     "karma-mocha": "^0.2.0",
     "karma-mocha-reporter": "^1.0.2",

--- a/src/doc.jsx
+++ b/src/doc.jsx
@@ -1,6 +1,6 @@
 "use strict";
 
-import React from "react/addons";
+import React from "react";
 
 var propTypesArray = [{
   key: "array",
@@ -60,7 +60,7 @@ var getReactPropType = function (propTypeFunc) {
   return propType;
 };
 
-module.exports = React.createClass({
+export default React.createClass({
   propTypes: {
     componentClass: React.PropTypes.renderable,
     propDescriptionMap: React.PropTypes.object,

--- a/src/editor.jsx
+++ b/src/editor.jsx
@@ -1,7 +1,7 @@
 /* eslint new-cap:0 no-unused-vars:0 */
 "use strict";
 
-import React from "react/addons";
+import React from "react";
 
 const Editor = React.createClass({
   componentDidMount() {

--- a/src/es6-preview.jsx
+++ b/src/es6-preview.jsx
@@ -1,7 +1,7 @@
 /* eslint new-cap:0 no-unused-vars:0 */
 "use strict";
 
-import React from "react/addons";
+import React from "react";
 import babel from "babel-core/browser";
 
 const getType = function (el) {

--- a/src/playground.jsx
+++ b/src/playground.jsx
@@ -1,8 +1,8 @@
-/* no-unused-vars:0 */
+/* eslint no-unused-vars:0 */
 "use strict";
 
 import polyfill from "babel/polyfill";
-import React from "react/addons";
+import React from "react";
 
 import Editor from "./editor";
 import Preview from "./preview";
@@ -20,7 +20,8 @@ const ReactPlayground = React.createClass({
     noRender: React.PropTypes.bool,
     es6Console: React.PropTypes.bool,
     context: React.PropTypes.object,
-    initiallyExpanded: React.PropTypes.bool
+    initiallyExpanded: React.PropTypes.bool,
+    previewComponent: React.PropTypes.node
   },
 
   getDefaultProps() {
@@ -90,7 +91,8 @@ const ReactPlayground = React.createClass({
             context={this.props.context}
             code={this.state.code}
             scope={this.props.scope}
-            noRender={this.props.noRender} />
+            noRender={this.props.noRender}
+            previewComponent={this.props.previewComponent} />
           }
         </div>
       </div>

--- a/src/preview.jsx
+++ b/src/preview.jsx
@@ -1,12 +1,13 @@
 "use strict";
 
-import React from "react/addons";
+import React from "react";
 import babel from "babel-core/browser";
 
 const Preview = React.createClass({
     propTypes: {
-      code: React.PropTypes.string.isRequired,
-      scope: React.PropTypes.object.isRequired
+      code: PropTypes.string.isRequired,
+      scope: PropTypes.object.isRequired,
+      previewComponent: PropTypes.node
     },
 
     getInitialState() {
@@ -90,9 +91,8 @@ const Preview = React.createClass({
           error: null
         });
       } catch (err) {
-        var self = this;
-        this._setTimeout(function () {
-          self.setState({
+        this._setTimeout(() => {
+          this.setState({
             error: err.toString()
           });
         }, 500);

--- a/src/preview.jsx
+++ b/src/preview.jsx
@@ -16,6 +16,12 @@ const Preview = React.createClass({
       };
     },
 
+    getDefaultProps() {
+      return {
+        previewComponent: 'div'
+      }
+    },
+
     componentDidMount() {
       this._executeCode();
     },
@@ -82,7 +88,10 @@ const Preview = React.createClass({
           var Component = React.createElement(
             eval(compiledCode).apply(null, scope)
           );
-          React.render(Component, mountNode);
+          React.render(
+            React.createElement(this.props.previewComponent, {}, Component),
+            mountNode
+          );
         } else {
           eval(compiledCode).apply(null, scope);
         }


### PR DESCRIPTION
I didn’t update eslint deps because some of the rules changes. Also, eslint is failing for me as is so ¯\_(ツ)_/¯

The preview rendering component allows the community to extend the component playground in extremely interesting ways. For example,  I’m currently creating a responsive renderer which will render a given component into an iFrame with all of the current pages styles injected like so:

<img width="747" alt="screen shot 2015-09-17 at 4 40 07 pm" src="https://cloud.githubusercontent.com/assets/227879/9945349/c8c69f32-5d5a-11e5-814e-ad813a0d784e.png">
