### PR TITLE
check for lib in postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/FormidableLabs/component-playground/issues"
   },
   "scripts": {
-    "postinstall": "npm run build-lib",
+    "postinstall": "node -e \"require('fs').stat('lib', function(e,s){process.exit(e || !s.isDirectory() ? 1 : 0)})\" || npm run build-lib",
     "preversion": "npm run check",
     "version": "npm run clean && npm run build && git add -A dist",
     "clean-dist": "rimraf dist",


### PR DESCRIPTION
@kenwheeler or @rgerstenberger 

npm install fails the first time with a particular combination of node + npm versions. This implements the fix we've been using on victory stuff.  

More detail here:
https://github.com/FormidableLabs/formidable-react-component-boilerplate/issues/49

Can I get a version bump with this?

Thanks!