### PR TITLE
Feature: add line selection option

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -46,7 +46,7 @@ var Index = React.createClass({
         <Playground
           codeText={componentExample}
           scope={{React: React, Button: Button}}
-          selection={{startLine: 2, endLine: 4}}/>
+          selectedLines={[2, 3, 4, 9]}/>
 
         <h2>Prop Descriptions</h2>
 

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -41,6 +41,13 @@ var Index = React.createClass({
           collapsableCode={true}
           initiallyExpanded/>
 
+        <h2>Code Selection Highlighting</h2>
+
+        <Playground
+          codeText={componentExample}
+          scope={{React: React, Button: Button}}
+          selection={{startLine: 2, endLine: 4}}/>
+
         <h2>Prop Descriptions</h2>
 
         <Playground

--- a/src/components/editor.jsx
+++ b/src/components/editor.jsx
@@ -1,6 +1,7 @@
 /* eslint new-cap:0 no-unused-vars:0 */
 import React from "react";
 import CodeMirror from "codemirror";
+
 require("codemirror/mode/javascript/javascript");
 
 const Editor = React.createClass({
@@ -30,7 +31,7 @@ const Editor = React.createClass({
     });
 
     if (this.props.selection && this.props.selection.startLine <= this.props.selection.endLine) {
-      for (var i = this.props.selection.startLine; i <= this.props.selection.endLine; i++) {
+      for (let i = this.props.selection.startLine; i <= this.props.selection.endLine; i++) {
         this.editor.addLineClass(i, "wrap", "CodeMirror-activeline-background");
       }
     }

--- a/src/components/editor.jsx
+++ b/src/components/editor.jsx
@@ -3,13 +3,16 @@ import React from "react";
 import CodeMirror from "codemirror";
 require("codemirror/mode/javascript/javascript");
 
-
 const Editor = React.createClass({
   propTypes: {
     theme: React.PropTypes.string,
     readOnly: React.PropTypes.bool,
     external: React.PropTypes.bool,
     codeText: React.PropTypes.string,
+    selection: React.PropTypes.shape({
+      startLine: React.PropTypes.number,
+      endLine: React.PropTypes.number
+    }),
     onChange: React.PropTypes.func,
     style: React.PropTypes.object,
     className: React.PropTypes.string
@@ -22,8 +25,16 @@ const Editor = React.createClass({
       smartIndent: false,
       matchBrackets: true,
       theme: this.props.theme,
-      readOnly: this.props.readOnly
+      readOnly: this.props.readOnly,
+      styleSelectedText: this.props.selection ? true : false
     });
+
+    if (this.props.selection && this.props.selection.startLine <= this.props.selection.endLine) {
+      for (var i = this.props.selection.startLine; i <= this.props.selection.endLine; i++) {
+        this.editor.addLineClass(i, "wrap", "CodeMirror-activeline-background");
+      }
+    }
+
     this.editor.on("change", this._handleChange);
   },
 

--- a/src/components/editor.jsx
+++ b/src/components/editor.jsx
@@ -10,10 +10,7 @@ const Editor = React.createClass({
     readOnly: React.PropTypes.bool,
     external: React.PropTypes.bool,
     codeText: React.PropTypes.string,
-    selection: React.PropTypes.shape({
-      startLine: React.PropTypes.number,
-      endLine: React.PropTypes.number
-    }),
+    selectedLines: React.PropTypes.array,
     onChange: React.PropTypes.func,
     style: React.PropTypes.object,
     className: React.PropTypes.string
@@ -26,14 +23,13 @@ const Editor = React.createClass({
       smartIndent: false,
       matchBrackets: true,
       theme: this.props.theme,
-      readOnly: this.props.readOnly,
-      styleSelectedText: this.props.selection ? true : false
+      readOnly: this.props.readOnly
     });
 
-    if (this.props.selection && this.props.selection.startLine <= this.props.selection.endLine) {
-      for (let i = this.props.selection.startLine; i <= this.props.selection.endLine; i++) {
-        this.editor.addLineClass(i, "wrap", "CodeMirror-activeline-background");
-      }
+    if (Array.isArray(this.props.selectedLines)) {
+      this.props.selectedLines.forEach((lineNumber) => {
+        this.editor.addLineClass(lineNumber, "wrap", "CodeMirror-activeline-background");
+      });
     }
 
     this.editor.on("change", this._handleChange);

--- a/src/components/playground.jsx
+++ b/src/components/playground.jsx
@@ -16,6 +16,10 @@ const ReactPlayground = React.createClass({
     docClass: React.PropTypes.func,
     propDescriptionMap: React.PropTypes.object,
     theme: React.PropTypes.string,
+    selection: React.PropTypes.shape({
+      startLine: React.PropTypes.number,
+      endLine: React.PropTypes.number
+    }),
     noRender: React.PropTypes.bool,
     es6Console: React.PropTypes.bool,
     context: React.PropTypes.object,
@@ -88,7 +92,8 @@ const ReactPlayground = React.createClass({
             className="playgroundStage"
             codeText={this.state.code}
             external={this.state.external}
-            theme={this.props.theme} />
+            theme={this.props.theme}
+            selection={this.props.selection}/>
         </div>
         {this.props.collapsableCode ?
           <div className="playgroundToggleCodeBar">

--- a/src/components/playground.jsx
+++ b/src/components/playground.jsx
@@ -16,10 +16,7 @@ const ReactPlayground = React.createClass({
     docClass: React.PropTypes.func,
     propDescriptionMap: React.PropTypes.object,
     theme: React.PropTypes.string,
-    selection: React.PropTypes.shape({
-      startLine: React.PropTypes.number,
-      endLine: React.PropTypes.number
-    }),
+    selectedLines: React.PropTypes.array,
     noRender: React.PropTypes.bool,
     es6Console: React.PropTypes.bool,
     context: React.PropTypes.object,
@@ -93,7 +90,7 @@ const ReactPlayground = React.createClass({
             codeText={this.state.code}
             external={this.state.external}
             theme={this.props.theme}
-            selection={this.props.selection}/>
+            selectedLines={this.props.selectedLines}/>
         </div>
         {this.props.collapsableCode ?
           <div className="playgroundToggleCodeBar">


### PR DESCRIPTION
This adds the ability to pass in a `selection` to be highlighted. `selection={{startLine: 2, endLine: 4}}` both `endLine` and `startLine` are inclusive. To highlight a single line pass in the same line number for both start and end. Uses `CodeMirror-activeline-background` class under the hood to allow for theming.

![screen shot 2016-04-06 at 12 06 16 pm](https://cloud.githubusercontent.com/assets/710017/14329396/febb0bee-fbef-11e5-803d-c838210d9e2c.png)
