### PR TITLE
Update CodeMirror to JSX mode

### DIFF
--- a/src/components/editor.jsx
+++ b/src/components/editor.jsx
@@ -2,7 +2,7 @@
 import React from "react";
 import CodeMirror from "codemirror";
 
-require("codemirror/mode/javascript/javascript");
+require("codemirror/mode/jsx/jsx");
 
 const Editor = React.createClass({
   propTypes: {
@@ -17,7 +17,7 @@ const Editor = React.createClass({
   },
   componentDidMount() {
     this.editor = CodeMirror.fromTextArea(this.refs.editor, {
-      mode: "javascript",
+      mode: "jsx",
       lineNumbers: false,
       lineWrapping: true,
       smartIndent: false,


### PR DESCRIPTION
Does what it says on the tin. No more weird JSX syntax highlighting.

If we don't want this outright, another option would be to accept CodeMirror option overrides as a prop (https://github.com/FormidableLabs/component-playground/issues/36). Let me know if that would be better and I'll do it instead.

/cc @kenwheeler @rgerstenberger 