### PR TITLE
Relax version specifier for "react" 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "codemirror": "^5.12.0",
     "css-loader": "~0.9.0",
     "react-addons-test-utils": "^15.0.0 || ^0.14.7",
-    "react": "15.0.1 || ^0.14.7",
+    "react": "^15.0.1 || ^0.14.7",
     "react-dom": "^15.0.1 || ^0.14.7",
     "rimraf": "^2.4.0",
     "style-loader": "~0.8.0",


### PR DESCRIPTION
Looks like the caret was unintentionally left out in b2b3ab7f08557d77f641fdec8f7544df94720f40

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/formidablelabs/component-playground/65)
<!-- Reviewable:end -->
