### PR TITLE
Upgrade lodash to v4.13

### DIFF
--- a/demo/webpack.config.hot.js
+++ b/demo/webpack.config.hot.js
@@ -1,14 +1,16 @@
 "use strict";
 
-var _ = require("lodash");
+var cloneDeep = require("lodash/cloneDeep");
+var merge = require("lodash/merge");
+var omit = require("lodash/omit");
 var base = require("./webpack.config.dev");
 
 // Update our own module version.
-var mod = _.cloneDeep(base.module);
+var mod = cloneDeep(base.module);
 // First loader needs react hot.
 mod.loaders[0].loaders = ["react-hot"].concat(mod.loaders[0].loaders);
 
-module.exports = _.merge({}, _.omit(base, "entry", "module"), {
+module.exports = merge({}, omit(base, "entry", "module"), {
   entry: {
     app: ["webpack/hot/dev-server", "./demo/app.jsx"]
   },

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "karma-sauce-launcher": "^0.2.14",
     "karma-spec-reporter": "0.0.20",
     "karma-webpack": "^1.6.0",
-    "lodash": "^3.9.3",
+    "lodash": "^4.13.1",
     "mocha": "^2.2.5",
     "opener": "^1.4.1",
     "phantomjs": "^1.9.17",

--- a/webpack.config.coverage.js
+++ b/webpack.config.coverage.js
@@ -2,10 +2,10 @@
 /**
  * Webpack frontend test (w/ coverage) configuration.
  */
-var _ = require("lodash");
+var merge = require("lodash/merge");
 var testCfg = require("./webpack.config.test");
 
-module.exports = _.merge({}, testCfg, {
+module.exports = merge({}, testCfg, {
   isparta: {
     babel: {
       presets: ["es2015", "stage-1", "react"]

--- a/webpack.config.test.js
+++ b/webpack.config.test.js
@@ -3,7 +3,7 @@
  * Webpack frontend test configuration.
  */
 var path = require("path");
-var _ = require("lodash");
+var merge = require("lodash/merge");
 var prodCfg = require("./webpack.config");
 var webpack = require("webpack");
 
@@ -16,7 +16,7 @@ module.exports = {
     filename: "main.js",
     publicPath: "/assets/"
   },
-  resolve: _.merge({}, prodCfg.resolve, {
+  resolve: merge({}, prodCfg.resolve, {
     alias: {
       // Allow root import of `src/FOO` from ROOT/src.
       src: path.join(__dirname, "src")


### PR DESCRIPTION
Problem:
Babel v6 depends on lodash v4.
npm v3 flattens and resolves to lodash v3.9 (from component-playground’s dependencies), and a babel error appears. 

Solution:
This PR upgrades component-playground’s lodash to v4. Babel error disappears.

/cc @coopy @rgerstenberger @kenwheeler 