### PR TITLE
Remove noRender deprecatation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,14 +137,13 @@ Turns preview into a simple console for testing out ES6 code. Use `console.log()
   codeText={es6Example} />
 ```
 
-### noRender - (Deprecated, Remove at 1.x)
+### noRender
 _React.PropTypes.bool_
 
-If set to false, allows you bypass the `component-playground`'s component wrapper and render method.
+Defaults to true. If set to false, allows you bypass the `component-playground`'s component wrapper and render method.
 You can use this option to write higher order components directly in your example code and use your
 own Render method.
-NODE: This option **requires** that the `React.render` method be in your code
-_Deprecated in favor of writing example components. See #19 for more information_
+NOTE: This option **requires** that the `React.render` method be in your code
 
 ```
 var ComponentExample = React.createClass({

--- a/src/components/playground.jsx
+++ b/src/components/playground.jsx
@@ -70,19 +70,6 @@ class ReactPlayground extends Component {
       selectedLines,
       theme } = this.props;
 
-    if (this.props.noRender === false) {
-      if (process.env.NODE_ENV !== "production") {
-        /* eslint-disable no-console, no-undef, max-len */
-        if (typeof console !== "undefined" && console.warn) {
-          console.warn(`
-            Deprecation warning: noRender is being deprecated in favor of wrapped components and will be removed in the 1.x release.
-            https://github.com/FormidableLabs/component-playground/issues/19 for details.
-          `);
-        }
-        /* eslint-enable no-console, no-undef, max-len */
-      }
-    }
-
     return (
       <div className={`playground${collapsableCode ? " collapsableCode" : ""}`}>
         {


### PR DESCRIPTION
1. After talking with @baer and @paulathevalley it sounds like #19 is probably not going to be implemented: `noRender` won't be deprecated after all.
2. This warning can be maddening when trying to develop.
<img width="547" alt="victory___tutorials_" src="https://cloud.githubusercontent.com/assets/2822048/17575400/eb9a7482-5f36-11e6-94d0-63ae2eacfdf3.png">
3. We can always revert this commit if we do decide to deprecate 💃
