### PR TITLE
logging errors in the console instead of the dom

### DIFF
--- a/src/components/preview.jsx
+++ b/src/components/preview.jsx
@@ -1,3 +1,4 @@
+
 import React, { Component, PropTypes } from "react";
 import { render } from "react-dom";
 import ReactDOMServer from "react-dom/server";
@@ -109,10 +110,14 @@ class Preview extends Component {
 
   render() {
     const { error } = this.state;
+    if (error) {
+      console.error(error); //eslint-disable-line no-undef, no-console
+    }
+
     return (
       <div>
         {error !== null ?
-          <div className="playgroundError">{error}</div> :
+          <div className="playgroundError">Error! See console output for more information.</div> :
           null}
         <div ref="mount" className="previewArea"/>
       </div>


### PR DESCRIPTION
This might close https://github.com/FormidableLabs/component-playground/issues/13.

Instead of rendering errors to the dom it will log them to the console. This gives much better formatting, and now proptype warnings and error messages are in the same place.
Now:
![screen shot 2016-11-11 at 4 45 09 pm](https://cloud.githubusercontent.com/assets/4106035/20234474/aac0d350-a830-11e6-9e32-5b313244b2c0.png)
![screen shot 2016-11-11 at 4 44 01 pm](https://cloud.githubusercontent.com/assets/4106035/20234471/a3c0dc8a-a830-11e6-8406-66355b79779d.png)

Before:
![screen shot 2016-11-11 at 4 44 48 pm](https://cloud.githubusercontent.com/assets/4106035/20234475/b63c949e-a830-11e6-982c-d8bb84e5ee86.png)


