### PR TITLE
Conditionally import JSX codemirror mode for SSR

### DIFF
--- a/src/components/editor.jsx
+++ b/src/components/editor.jsx
@@ -2,7 +2,9 @@
 import React, { Component, PropTypes } from "react";
 import Codemirror from "react-codemirror";
 
-require("codemirror/mode/jsx/jsx");
+if (typeof window !== "undefined") {
+  require("codemirror/mode/jsx/jsx");
+}
 
 class Editor extends Component {
 


### PR DESCRIPTION
Without this condition, we attempt to load the codemirror mode on the server, which breaks because it depends on being used in the browser. With this change, you can safely use component playground in server (and static) renders. :metal:

Resolves #75  

/cc @kenwheeler @paulathevalley 