### PR TITLE
[Proposal] Replace babel-standalone with buble

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "babel-preset-react": "^6.0.0",
     "babel-preset-stage-0": "^6.0.0",
     "babel-preset-stage-1": "^6.0.0",
-    "babel-standalone": "^6.4.4",
+    "buble": "^0.15.2",
     "codemirror": "^5.15.2",
     "css-loader": "~0.9.0",
     "react": "^15.0.1 || ^0.14.7",

--- a/src/components/es6-preview.jsx
+++ b/src/components/es6-preview.jsx
@@ -1,7 +1,7 @@
 /* eslint new-cap:0 no-unused-vars:0 */
 import React, { Component, PropTypes } from "react";
 import { render, unmountComponentAtNode } from "react-dom";
-import { transform } from "babel-standalone";
+import { transform } from "buble";
 
 const getType = function (el) {
   let t = typeof el;
@@ -97,7 +97,7 @@ class EsPreview extends Component {
         ${code}
         return list;
       });
-    `, { presets: ["es2015", "react", "stage-1"] }).code;
+    `).code;
   };
 
   _setTimeout = (...args) => {

--- a/src/components/preview.jsx
+++ b/src/components/preview.jsx
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from "react";
 import { render } from "react-dom";
 import ReactDOMServer from "react-dom/server";
-import { transform } from "babel-standalone";
+import { transform } from "buble";
 
 class Preview extends Component {
 
@@ -48,13 +48,13 @@ class Preview extends Component {
 
           return Comp;
         });
-      `, { presets: ["es2015", "react", "stage-1"] }).code;
+      `).code;
     } else {
       return transform(`
         ((${Object.keys(scope).join(",")}, mountNode) => {
           ${code}
         });
-      `, { presets: ["es2015", "react", "stage-1"] }).code;
+      `).code;
     }
 
   };


### PR DESCRIPTION
I wanted to see whether I can get a little discussion going here. 😉

I was actually starting to use the playground for a website I'm building and besides getting server-side-rendering to work by rewriting some parts from scratch for my limited use-case, I noticed that the bundle-size is ginormous, as to be expected from `babel-standalone`. 😮

So I swapped it out with `buble` (Yeah, I know. Not good old Babel) and it actually results in half (!) the bundle size. So I think it's worth giving this a thought, I hope 😄

(Btw `karma` is not working for me, but I haven't looked into it yet, to see why exactly it isn't)

Edit:

```
1.8M 14 Feb   01:33 | component-playground.js
607K 14 Feb   01:33 | component-playground.min.js
```