### PR TITLE
Move prop-types to peerDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Component Playground Changelog
 
+## Unreleased
+
+  * Move `prop-types` to `peerDependencies`
+
 ## 2.0.0 (2017-05-18)
 
   * Remove support for React < v15

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,7 +3,7 @@
 ## Props
 
 ### `codeText` (required)
-*React.propTypes.string.isRequired*
+*PropTypes.string.isRequired*
 
 codeText takes a string of JSX markup as its value. While you can just pass it a string, we find it's easier to make a separate file and use Webpack's raw loader to load in the raw source. In the example above, we used the `.example` extension, and an examples folder to organize my samples. The only requirement for this code is that at the bottom you need to add:
 
@@ -26,7 +26,7 @@ ReactDOM.render(<ComponentExample/>, mountNode);
 ```
 
 ### `scope` (required)
-*React.PropTypes.object.isRequired*
+*PropTypes.object.isRequired*
 
 When evaluating the JSX, it needs to be provided a scope object. At the very least, React needs to be provided to the scope, if any custom tags aren't being used. See below:
 
@@ -37,12 +37,12 @@ When evaluating the JSX, it needs to be provided a scope object. At the very lea
 Any module/component that is used inside the playground needs to be added to the scope object. See the Getting Started Guide for an example of how this works.
 
 ### `theme`
-*React.propTypes.string*
+*PropTypes.string*
 
 String specifying which CodeMirror theme to initialize with. Defaults to "monokai."
 
 ### `noRender`
-*React.propTypes.bool*
+*PropTypes.bool*
 
 If set to true, removes the need to create a class or call ReactDOM.render() within the example code. When true, examples should be structured as the interior of a render method, see below:
 
@@ -53,7 +53,7 @@ If set to true, removes the need to create a class or call ReactDOM.render() wit
 ```
 
 ### `collapsableCode`
-*React.propTypes.bool*
+*PropTypes.bool*
 
 Allows the user to collapse the code block.
 
@@ -62,7 +62,7 @@ Allows the user to collapse the code block.
 ```
 
 ### `docClass`
-*React.propTypes.renderable*
+*PropTypes.renderable*
 
 A component class that will be used to auto-generate docs based on that component's propTypes. See propDescriptionMap below for how to annotate the generate prop docs.
 
@@ -71,7 +71,7 @@ A component class that will be used to auto-generate docs based on that componen
 ```
 
 ### `propDescriptionMap`
-*React.propTypes.string*
+*PropTypes.string*
 
 Annotation map for the docClass. They key is the prop to annotate, the value is the description of that prop.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Set Up
 
-In your HTML document, add the required CodeMirror scripts at the bottom, before your bundle script: 
+In your HTML document, add the required CodeMirror scripts at the bottom, before your bundle script:
 
 ```html
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -70,14 +70,14 @@
     "babel-preset-stage-1": "^6.24.1",
     "babel-standalone": "^6.26.0",
     "codemirror": "^5.30.0",
-    "prop-types": "^15.6.0",
     "react-codemirror2": "^2.0.2",
     "rimraf": "^2.6.2",
     "webpack": "^1.15.0"
   },
   "peerDependencies": {
     "react": "^15.6.0 || ^16.0.0",
-    "react-dom": "^15.6.0 || ^16.0.0"
+    "react-dom": "^15.6.0 || ^16.0.0",
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.0.1",
@@ -107,6 +107,7 @@
     "mocha": "^2.2.5",
     "opener": "^1.4.1",
     "phantomjs-prebuilt": "^2.1.15",
+    "prop-types": "^15.6.0",
     "publishr": "^1.0.0",
     "raw-loader": "^0.5.1",
     "react": "^15.6.0 || ^16.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,12 @@ module.exports = {
         commonjs2: "react-dom",
         commonjs: "react-dom",
         amd: "react-dom"
+      },
+      "prop-types": {
+        root: "PropTypes",
+        commonjs2: "prop-types",
+        commonjs: "prop-types",
+        amd: "prop-types"
       }
     }
   ],


### PR DESCRIPTION
Move `prop-types` to `peerDependencies` (and `devDependencies` so they're available during development/testing/etc.) Fixes #113.

Bonus: Update `React.PropTypes` references in the docs.

Down the line this should be included in a major release since it will break consumers who don't already have `prop-types` installed.

@ryan-roemer @kenwheeler Do you know if we have any CodePen/JSBin/etc. type pages demoing Component Playground that will need to be updated to include `prop-types`?