### PR TITLE
propObj is a template literal again

### DIFF
--- a/src/components/doc.jsx
+++ b/src/components/doc.jsx
@@ -92,7 +92,7 @@ class Doc extends Component {
           {
             propTypes.map((propObj) => (
               <li key={propObj.propName}>
-                <b>`${propObj.propName}: `</b>
+                <b>{`${propObj.propName}: `}</b>
                 <i>{propObj.type.name}</i>
                 {propObj.description && ` - ${ propObj.description}`}
                 <b>{`${propObj.type.isRequired ? " required" : ""}`}</b>


### PR DESCRIPTION
Should solve the problem of backticks appearing in generated docs.

Closes #120 