### PR TITLE
update to latest version of react-codemirror and resolve breaking cha…

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "babel-standalone": "^6.26.0",
     "codemirror": "^5.30.0",
     "prop-types": "^15.6.0",
-    "react-codemirror2": "^2.0.2",
+    "react-codemirror2": "^5.0.0",
     "rimraf": "^2.6.2",
     "webpack": "^1.15.0"
   },

--- a/src/components/editor.jsx
+++ b/src/components/editor.jsx
@@ -1,7 +1,7 @@
 /* eslint new-cap:0 no-unused-vars:0 */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import Codemirror from "react-codemirror2";
+import { UnControlled as Codemirror } from "react-codemirror2";
 
 if (typeof window !== "undefined") {
   require("codemirror/mode/jsx/jsx");

--- a/src/components/editor.jsx
+++ b/src/components/editor.jsx
@@ -3,7 +3,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { UnControlled as Codemirror } from "react-codemirror2";
 
-if (typeof window !== "undefined") {
+if (typeof window !== "undefined" && typeof window.navigator !== "undefined") {
   require("codemirror/mode/jsx/jsx");
 }
 

--- a/src/components/playground.jsx
+++ b/src/components/playground.jsx
@@ -7,6 +7,8 @@ import Preview from "./preview";
 import EsPreview from "./es6-preview";
 import Doc from "./doc";
 
+// TODO: refactor to remove componentWillReceiveProps
+// eslint-disable-next-line react/no-deprecated
 class ReactPlayground extends Component {
 
   static defaultProps = {
@@ -60,6 +62,7 @@ class ReactPlayground extends Component {
   render() {
     const { code, external, expandedCode } = this.state;
     const {
+      codeText,
       collapsableCode,
       context,
       docClass,
@@ -83,7 +86,7 @@ class ReactPlayground extends Component {
         <div className={`playgroundCode${expandedCode ? " expandedCode" : ""}`}>
           <Editor
             className="playgroundStage"
-            codeText={code}
+            codeText={codeText}
             external={external}
             onChange={this._handleCodeChange}
             selectedLines={selectedLines}


### PR DESCRIPTION
…nges

This PR:
- **updates to the latest version of `react-codemirror2`.** The new version provides the component `UnControlled` rather than `Codemirror`. This component keeps track of its own code state, so we shouldn't update the text manually. Updating the code text with the `onChange` callback was causing each change to trigger a second `onChange` with the entire code text appearing as a change, and the cursor position being lost.
- **Adds an explicit check for `window.navigator` before requiring `codemirror`.** The use of `navigator` in `codemirror` is causing build errors 
```
  WebpackError: navigator is not defined
  - codemirror.js:18
    ~/codemirror/lib/codemirror.js:18:1
...
```