### PR TITLE
feat: adding ability to have hyphenated classnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,18 @@ var ComponentExample = React.createClass({
 React.render(<ComponentExample/>, mountNode);
 ```
 
+### hyphenatedClassNames
+_React.PropTypes.bool_
+
+Defaults to false. If set to false, allows return the classnames of the component wrapper and rest of them as hyphenated.
+You can use this option to have the classnames as hyphenated.
+
+```js
+  <Playground
+    hyphenatedClassNames={true}
+  />
+```
+
 ### Comparison to [react-live](https://github.com/FormidableLabs/react-live)
 
 There are multiple options when it comes to live, editable React component environments. Formidable actually has **two** first class projects to help you out: [`component-playground`](https://github.com/FormidableLabs/component-playground) and [`react-live`](https://github.com/FormidableLabs/react-live). Let's briefly look at the libraries, use cases, and factors that might help in deciding which is right for you.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build-es": "npm run clean-es && babel src --out-dir es",
     "clean": "npm run clean-lib && npm run clean-dist && npm run clean-es",
     "build": "npm run build-lib && npm run build-dist && npm run build-es",
-    "server-dev": "webpack-dev-server --port 3000 --config demo/webpack.config.dev.js --content-base demo",
+    "server-dev": "webpack-dev-server --port 4000 --config demo/webpack.config.dev.js --content-base demo",
     "server-hot": "webpack-dev-server --port 3000 --config demo/webpack.config.hot.js --hot --content-base demo",
     "server-test": "webpack-dev-server --port 3001 --config webpack.config.test.js",
     "dev": "npm run server-dev & npm run server-test",

--- a/src/components/doc.jsx
+++ b/src/components/doc.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { getHyphenatedClassNames } from '../utils/string';
 
 const propTypesArray = [{
   key: "array",
@@ -65,7 +66,8 @@ class Doc extends Component {
   static propTypes = {
     componentClass: PropTypes.func,
     ignore: PropTypes.array,
-    propDescriptionMap: PropTypes.object
+    propDescriptionMap: PropTypes.object,
+    hyphenatedClassNames: PropTypes.bool
   };
 
   render() {
@@ -74,7 +76,8 @@ class Doc extends Component {
     const {
       componentClass,
       ignore,
-      propDescriptionMap
+      propDescriptionMap,
+      hyphenatedClassNames = false
     } = this.props;
     for (const propName in componentClass.propTypes) {
       if (ignore.indexOf(propName)) {
@@ -87,7 +90,7 @@ class Doc extends Component {
     }
 
     return (
-      <div className="playgroundDocs">
+      <div className={getHyphenatedClassNames("playgroundDocs", hyphenatedClassNames)}>
         <ul>
           {
             propTypes.map((propObj) => (

--- a/src/components/es6-preview.jsx
+++ b/src/components/es6-preview.jsx
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { render, unmountComponentAtNode } from "react-dom";
 import { transform } from "babel-standalone";
+import { getHyphenatedClassNames } from '../utils/string';
 
 const getType = function (el) {
   let t = typeof el;
@@ -84,7 +85,8 @@ class EsPreview extends Component {
 
   static propTypes = {
     code: PropTypes.string.isRequired,
-    scope: PropTypes.object.isRequired
+    scope: PropTypes.object.isRequired,
+    hyphenatedClassNames: PropTypes.bool
   };
 
   _compileCode = () => {
@@ -108,6 +110,7 @@ class EsPreview extends Component {
 
   _executeCode = () => {
     const mountNode = this.mount;
+    const { hyphenatedClassNames = false } = this.props;
 
     try {
       unmountComponentAtNode(mountNode);
@@ -155,7 +158,7 @@ class EsPreview extends Component {
     } catch (err) {
       this._setTimeout(() => {
         render(
-          <div className="playgroundError">{err.toString()}</div>,
+          <div className={getHyphenatedClassNames("playgroundError", hyphenatedClassNames)}>{err.toString()}</div>,
           mountNode
         );
       }, 500);

--- a/src/components/playground.jsx
+++ b/src/components/playground.jsx
@@ -6,6 +6,7 @@ import Editor from "./editor";
 import Preview from "./preview";
 import EsPreview from "./es6-preview";
 import Doc from "./doc";
+import { getHyphenatedClassNames } from '../utils/string';
 
 // TODO: refactor to remove componentWillReceiveProps
 // eslint-disable-next-line react/no-deprecated
@@ -30,7 +31,8 @@ class ReactPlayground extends Component {
     es6Console: PropTypes.bool,
     context: PropTypes.object,
     initiallyExpanded: PropTypes.bool,
-    previewComponent: PropTypes.node
+    previewComponent: PropTypes.node,
+    hyphenatedClassNames: PropTypes.node
   };
 
   state = {
@@ -72,20 +74,23 @@ class ReactPlayground extends Component {
       propDescriptionMap,
       scope,
       selectedLines,
-      theme } = this.props;
+      theme,
+      hyphenatedClassNames = false
+    } = this.props;
 
     return (
-      <div className={`playground${collapsableCode ? " collapsableCode" : ""}`}>
+      <div className={collapsableCode ? getHyphenatedClassNames("playground collapsableCode", hyphenatedClassNames) : "playground"}>
         {
           docClass ?
             <Doc
               componentClass={docClass}
               propDescriptionMap={propDescriptionMap}
+              hyphenatedClassNames={hyphenatedClassNames}
             /> : null
         }
-        <div className={`playgroundCode${expandedCode ? " expandedCode" : ""}`}>
+        <div className={expandedCode ? getHyphenatedClassNames("playgroundCode expandedCode", hyphenatedClassNames) : getHyphenatedClassNames("playgroundCode", hyphenatedClassNames)}>
           <Editor
-            className="playgroundStage"
+            className={getHyphenatedClassNames("playgroundStage", hyphenatedClassNames)}
             codeText={codeText}
             external={external}
             onChange={this._handleCodeChange}
@@ -95,18 +100,19 @@ class ReactPlayground extends Component {
         </div>
         {
           collapsableCode ?
-            <div className="playgroundToggleCodeBar">
-              <span className="playgroundToggleCodeLink" onClick={this._toggleCode}>
+            <div className={getHyphenatedClassNames("playgroundToggleCodeBar", hyphenatedClassNames)}>
+              <span className={getHyphenatedClassNames("playgroundToggleCodeLink", hyphenatedClassNames)} onClick={this._toggleCode}>
                 {expandedCode ? "collapse" : "expand"}
               </span>
             </div> : null
         }
-        <div className="playgroundPreview">
+        <div className={getHyphenatedClassNames("playgroundPreview", hyphenatedClassNames)}>
           {
             es6Console ?
               <EsPreview
                 code={code}
                 scope={scope}
+                hyphenatedClassNames={hyphenatedClassNames}
               /> :
               <Preview
                 context={context}
@@ -114,6 +120,7 @@ class ReactPlayground extends Component {
                 scope={scope}
                 noRender={noRender}
                 previewComponent={previewComponent}
+                hyphenatedClassNames={hyphenatedClassNames}
               />
           }
         </div>

--- a/src/components/preview.jsx
+++ b/src/components/preview.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import { render } from "react-dom";
 import ReactDOMServer from "react-dom/server";
 import { transform } from "babel-standalone";
+import { getHyphenatedClassNames } from '../utils/string';
 
 class Preview extends Component {
 
@@ -16,7 +17,8 @@ class Preview extends Component {
     scope: PropTypes.object.isRequired,
     previewComponent: PropTypes.node,
     noRender: PropTypes.bool,
-    context: PropTypes.object
+    context: PropTypes.object,
+    hyphenatedClassNames: PropTypes.bool
   };
 
   state = {
@@ -112,12 +114,13 @@ class Preview extends Component {
 
   render() {
     const { error } = this.state;
+    const { hyphenatedClassNames = false } = this.props;
     return (
       <div>
         {error !== null ?
-          <div className="playgroundError">{error}</div> :
+          <div className={getHyphenatedClassNames("playgroundError", hyphenatedClassNames)}>{error}</div> :
           null}
-        <div ref={(c) => { this.mount = c; }} className="previewArea"/>
+        <div ref={(c) => { this.mount = c; }} className={getHyphenatedClassNames("previewArea", hyphenatedClassNames)} />
       </div>
     );
   }

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -1,0 +1,3 @@
+export function getHyphenatedClassNames(className, flag) {
+  return flag ? className.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase() : className;
+}


### PR DESCRIPTION
So this PR is to have the classnames as hyphenated. We have few project using the module, where we overridden the styles based on our requirement.
```
.previewArea,
.playgroundToggleCodeLink {
    white-space: normal;
    background-color: transparent;
}
```
Now the issue with these we are using [Sonar](https://www.sonarqube.org/) for our code quality check, which creating a lot bunch of them as the rule is set to hyphenated. To fix them, this is really necessary change.